### PR TITLE
feat: Derive Debug for RetryDecision

### DIFF
--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -6,6 +6,7 @@ pub trait RetryPolicy {
 }
 
 /// Outcome of evaluating a retry policy for a failed task.
+#[derive(Debug)]
 pub enum RetryDecision {
     /// Retry after the specified timestamp.
     Retry { execute_after: DateTime<Utc> },


### PR DESCRIPTION
It is useful to be able to log the outcome of a retry decision. This PR derives `Debug` for type `RetryDecision`.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/rust-retry-policies/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/rust-retry-policies/blob/main/CHANGELOG.md
-->
