### PR TITLE
README: fix link to ExponentialBackoff struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of plug-and-play retry policies for Rust projects.
 
 Currently available algorithms:
 
-- [`ExponentialBackoff`](https://docs.rs/retry-policies/0.1.2/retry_policies/policies/struct.ExponentialBackoff.html),
+- [`ExponentialBackoff`](https://docs.rs/retry-policies/latest/retry_policies/policies/struct.ExponentialBackoff.html),
   with decorrelated jitter.
 
 ## How to install

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of plug-and-play retry policies for Rust projects.
 
 Currently available algorithms:
 
-- [`ExponentialBackoff`](https://docs.rs/retry-policies/latest/retry-policies/policies/struct.ExponentialBackoff),
+- [`ExponentialBackoff`](https://docs.rs/retry-policies/0.1.2/retry_policies/policies/struct.ExponentialBackoff.html),
   with decorrelated jitter.
 
 ## How to install
@@ -19,7 +19,7 @@ Add `retry-policies` to your dependencies
 ```toml
 [dependencies]
 # ...
-retry-policies = "0.1.0"
+retry-policies = "0.1.2"
 ```
 
 #### License


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/rust-retry-policies/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/rust-retry-policies/blob/main/CHANGELOG.md
-->
