### PR TITLE
Fix markdown to make link clickable

### DIFF
--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -7,7 +7,7 @@ const MIN_JITTER: f64 = 0.0;
 const MAX_JITTER: f64 = 3.0;
 
 /// We are using the "decorrelated jitter" approach detailed here:
-/// `<https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>`
+/// <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExponentialBackoff {
     /// Maximum number of allowed retries attempts.


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/rust-retry-policies/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/rust-retry-policies/blob/main/CHANGELOG.md
-->



- `` `<https://example.com>` `` renders as `<https://example.com>`
- ``<https://example.com>`` renders as <https://example.com>