### PR TITLE
Change jitter implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
@@ -6,14 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-??-??
+
+### Changed
+
+- [Breaking] Jitter algorithm changed from a variation of decorrelated jitter to either none, full, or bounded.
+- [Breaking] Now requires a task start time when using a total retry duration.
+
 ## [0.1.2] - 2022-10-28
+
 ### Added
+
 - `Debug` derived for `RetryDecision`
 
 ## [0.1.1] - 2021-10-18
+
 ### Security
+
 - remove time v0.1 dependency
 
 ## [0.1.0] - 2021-08-11
+
 ### Added
+
 - `ExponentialBackoff` policy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [Breaking] Jitter algorithm changed from a variation of decorrelated jitter to either none, full, or bounded.
-- [Breaking] Now requires a task start time when using a total retry duration.
+- [Breaking] Change backoff and jitter algorithms
+  - Change the backoff algorithm to a more conventional exponential backoff.
+  - Replace the decorrelated jitter algorithm with an option of either none, full, or bounded. Defaults to full jitter.
+- [Breaking] Remove `ExponentialBackoffBuilder::backoff_exponent()`
+  - The number of attempts is now used as the exponent.
+- [Breaking] Require a task start time when using a total retry duration
+  - `ExponentialBackoffBuilder::build_with_total_retry_duration()` now returns `ExponentialBackoffTimed` which does not implement `RetryPolicy`.
+- [Breaking] Mark `ExponentialBackoff` as `non_exhaustive`
+  - Can no longer be constructed directly.
 
 ## [0.1.2] - 2022-10-28
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Add `retry-policies` to your dependencies
 retry-policies = "0.2.0"
 ```
 
-#### License
+## License
+
+<!-- markdownlint-disable MD033 -->
 
 <sup>
 Licensed under either of <a href="LICENSE-APACHE">Apache License, Version

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of plug-and-play retry policies for Rust projects.
 Currently available algorithms:
 
 - [`ExponentialBackoff`](https://docs.rs/retry-policies/latest/retry_policies/policies/struct.ExponentialBackoff.html),
-  with decorrelated jitter.
+  with configurable jitter.
 
 ## How to install
 
@@ -19,7 +19,7 @@ Add `retry-policies` to your dependencies
 ```toml
 [dependencies]
 # ...
-retry-policies = "0.1.2"
+retry-policies = "0.2.0"
 ```
 
 #### License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,4 @@
 pub mod policies;
 mod retry_policy;
 
-pub use retry_policy::{RetryDecision, RetryPolicy};
+pub use retry_policy::{Jitter, RetryDecision, RetryPolicy};

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -201,7 +201,7 @@ impl ExponentialBackoffBuilder {
     /// Builds an [`ExponentialBackoff`] with the given maximum total duration for which retries will
     /// continue to be performed.
     ///
-    /// Requires the use of [`ExponentialBackoff::for_task_started_at()`].
+    /// Requires the use of [`ExponentialBackoffTimed::for_task_started_at()`].
     ///
     /// # Example
     ///

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -1,28 +1,57 @@
-use crate::{RetryDecision, RetryPolicy};
+use crate::{Jitter, RetryDecision, RetryPolicy};
 use chrono::Utc;
 use rand::distributions::uniform::{UniformFloat, UniformSampler};
-use std::{cmp, time::Duration};
+use std::{
+    cmp::{self, min},
+    time::{Duration, Instant},
+};
 
-const MIN_JITTER: f64 = 0.0;
-const MAX_JITTER: f64 = 3.0;
-
-/// We are using the "decorrelated jitter" approach detailed here:
-/// <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>
+/// Exponential backoff with optional jitter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ExponentialBackoff {
     /// Maximum number of allowed retries attempts.
-    pub max_n_retries: u32,
-    /// Minimum waiting time between two retry attempts (it can end up being lower due to jittering).
+    pub max_n_retries: Option<u32>,
+    /// Maximum duration the retries can continue for, after which retries will stop.
+    pub max_total_retry_duration: Option<Duration>,
+    /// Minimum waiting time between two retry attempts (it can end up being lower when using full jitter).
     pub min_retry_interval: Duration,
     /// Maximum waiting time between two retry attempts.
     pub max_retry_interval: Duration,
-    /// Growing factor governing how fast the retry interval increases with respect to the number
-    /// of failed attempts. If set to 3:
-    /// - first retry: 3^0 = 1
-    /// - second retry: 3^1 = 3
-    /// - third retry: 3^2 = 9
-    /// ...
-    pub backoff_exponent: u32,
+    /// How we apply jitter to the calculated backoff intervals.
+    pub jitter: Jitter,
+}
+
+/// Exponential backoff with a maximum retry duration.
+pub struct ExponentialBackoffTimed {
+    inner: ExponentialBackoff,
+}
+
+/// Exponential backoff with a maximum retry duration, for a task with a known start time.
+pub struct ExponentialBackoffWithStart {
+    inner: ExponentialBackoff,
+    started_at: Instant,
+}
+
+/// Builds an exponential backoff policy.
+///
+/// # Example
+///
+/// ```rust
+/// use retry_policies::{RetryDecision, RetryPolicy, Jitter};
+/// use retry_policies::policies::ExponentialBackoff;
+/// use std::time::{Duration, Instant};
+///
+/// let backoff = ExponentialBackoff::builder()
+///     .retry_bounds(Duration::from_secs(1), Duration::from_secs(60))
+///     .jitter(Jitter::Bounded)
+///     .build_with_total_retry_duration(Duration::from_secs(24 * 60 * 60));
+///
+/// ```
+pub struct ExponentialBackoffBuilder {
+    min_retry_interval: Duration,
+    max_retry_interval: Duration,
+    jitter: Jitter,
 }
 
 impl ExponentialBackoff {
@@ -34,31 +63,50 @@ impl ExponentialBackoff {
     /// use std::time::Duration;
     ///
     /// let backoff = ExponentialBackoff::builder()
-    ///     .build_with_total_retry_duration(Duration::from_secs(24 * 60 * 60));
+    ///     .build_with_max_retries(5);
     ///
-    /// assert_eq!(backoff.backoff_exponent, 3);
     /// assert_eq!(backoff.min_retry_interval, Duration::from_secs(1));
     /// assert_eq!(backoff.max_retry_interval, Duration::from_secs(30 * 60));
-    /// assert_eq!(backoff.max_n_retries, 55); // calculated
+    /// assert_eq!(backoff.max_n_retries, Some(5));
     /// ```
     pub fn builder() -> ExponentialBackoffBuilder {
         <_>::default()
+    }
+
+    fn too_many_attempts(&self, n_past_retries: u32) -> bool {
+        self.max_n_retries
+            .is_some_and(|max_n| max_n <= n_past_retries)
     }
 }
 
 impl RetryPolicy for ExponentialBackoff {
     fn should_retry(&self, n_past_retries: u32) -> RetryDecision {
-        if n_past_retries >= self.max_n_retries {
+        if self.too_many_attempts(n_past_retries) {
             RetryDecision::DoNotRetry
         } else {
-            let unjittered_wait_for = self.min_retry_interval
-                * self
-                    .backoff_exponent
-                    .checked_pow(n_past_retries)
-                    .unwrap_or(u32::MAX);
-            let jitter_factor =
-                UniformFloat::<f64>::sample_single(MIN_JITTER, MAX_JITTER, &mut rand::thread_rng());
-            let jittered_wait_for = unjittered_wait_for.mul_f64(jitter_factor);
+            let unjittered_wait_for = min(
+                self.max_retry_interval,
+                self.min_retry_interval * 2_u32.checked_pow(n_past_retries).unwrap_or(u32::MAX),
+            );
+
+            let jittered_wait_for = match self.jitter {
+                Jitter::None => unjittered_wait_for,
+                Jitter::Full => {
+                    let jitter_factor =
+                        UniformFloat::<f64>::sample_single(0.0, 1.0, &mut rand::thread_rng());
+
+                    unjittered_wait_for.mul_f64(jitter_factor)
+                }
+                Jitter::Bounded => {
+                    let jitter_factor =
+                        UniformFloat::<f64>::sample_single(0.0, 1.0, &mut rand::thread_rng());
+
+                    let jittered_wait_for =
+                        (unjittered_wait_for - self.min_retry_interval).mul_f64(jitter_factor);
+
+                    jittered_wait_for + self.min_retry_interval
+                }
+            };
 
             let execute_after =
                 Utc::now() + clip_and_convert(jittered_wait_for, self.max_retry_interval);
@@ -67,17 +115,38 @@ impl RetryPolicy for ExponentialBackoff {
     }
 }
 
+impl ExponentialBackoffTimed {
+    pub fn for_task_started_at(&self, started_at: Instant) -> ExponentialBackoffWithStart {
+        ExponentialBackoffWithStart {
+            inner: self.inner,
+            started_at,
+        }
+    }
+}
+
+impl ExponentialBackoffWithStart {
+    fn trying_for_too_long(&self) -> bool {
+        self.inner
+            .max_total_retry_duration
+            .is_some_and(|max_d| max_d <= self.started_at.elapsed())
+    }
+}
+
+impl RetryPolicy for ExponentialBackoffWithStart {
+    fn should_retry(&self, n_past_retries: u32) -> RetryDecision {
+        if self.trying_for_too_long() {
+            RetryDecision::DoNotRetry
+        } else {
+            self.inner.should_retry(n_past_retries)
+        }
+    }
+}
+
 /// Clip to the maximum allowed retry interval and convert to chrono::Duration
 fn clip_and_convert(duration: Duration, max_duration: Duration) -> chrono::Duration {
     // Unwrapping is fine given that we are guaranteed to never exceed the maximum retry interval
-    // in magnitude and that is well withing range for chrono::Duration
+    // in magnitude and that is well within range for chrono::Duration
     chrono::Duration::from_std(cmp::min(duration, max_duration)).unwrap()
-}
-
-pub struct ExponentialBackoffBuilder {
-    min_retry_interval: Duration,
-    max_retry_interval: Duration,
-    backoff_exponent: u32,
 }
 
 impl Default for ExponentialBackoffBuilder {
@@ -85,7 +154,7 @@ impl Default for ExponentialBackoffBuilder {
         Self {
             min_retry_interval: Duration::from_secs(1),
             max_retry_interval: Duration::from_secs(30 * 60),
-            backoff_exponent: 3,
+            jitter: Jitter::Full,
         }
     }
 }
@@ -110,77 +179,59 @@ impl ExponentialBackoffBuilder {
         self
     }
 
-    /// Set backoff exponent. _Default 3_.
-    ///
-    /// See [`ExponentialBackoff::backoff_exponent`].
-    pub fn backoff_exponent(mut self, exponent: u32) -> Self {
-        self.backoff_exponent = exponent;
+    /// Set what type of jitter to apply.
+    pub fn jitter(mut self, jitter: Jitter) -> Self {
+        self.jitter = jitter;
         self
     }
 
-    /// Builds a [`ExponentialBackoff`] with the given maximum retries.
+    /// Builds an [`ExponentialBackoff`] with the given maximum retries.
     ///
     /// See [`ExponentialBackoff::max_n_retries`].
     pub fn build_with_max_retries(self, n: u32) -> ExponentialBackoff {
         ExponentialBackoff {
             min_retry_interval: self.min_retry_interval,
             max_retry_interval: self.max_retry_interval,
-            backoff_exponent: self.backoff_exponent,
-            max_n_retries: n,
+            max_n_retries: Some(n),
+            max_total_retry_duration: None,
+            jitter: self.jitter,
         }
     }
 
-    /// Builds a [`ExponentialBackoff`] with [`ExponentialBackoff::max_n_retries`] calculated
-    /// from an approximate total duration. So that after the resultant `max_n_retries` we'll
-    /// have (generally) retried past the given `total_duration`.
+    /// Builds an [`ExponentialBackoff`] with the given maximum total duration for which retries will
+    /// continue to be performed.
     ///
-    /// The _actual_ duration will be approximate due to retry jitter, though this calculation
-    /// is itself deterministic (based off mean jitter).
+    /// Requires the use of [`ExponentialBackoff::for_task_started_at()`].
     ///
     /// # Example
-    /// ```
+    ///
+    /// ```rust
+    /// use retry_policies::{RetryDecision, RetryPolicy};
     /// use retry_policies::policies::ExponentialBackoff;
-    /// use std::time::Duration;
+    /// use std::time::{Duration, Instant};
     ///
     /// let backoff = ExponentialBackoff::builder()
-    ///     .backoff_exponent(2)
-    ///     .retry_bounds(Duration::from_secs(1), Duration::from_secs(60 * 60))
-    ///     // set a retry count so we retry for ~3 hours
-    ///     .build_with_total_retry_duration(Duration::from_secs(3 * 60 * 60));
+    ///     .build_with_total_retry_duration(Duration::from_secs(24 * 60 * 60));
     ///
-    /// // mean delay steps: 1.5s, 3s, 6s, 12s, 24s, 48s, 96s, 192s,
-    /// //                   384s, 768s, 1536s, 3072s, 3600s, 3600s
-    /// // expected total delay: 13342.5s = 3.7h (least number of retries >= 3h)
-    /// assert_eq!(backoff.max_n_retries, 14);
+    /// let started_at = Instant::now()
+    ///     .checked_sub(Duration::from_secs(25 * 60 * 60)).unwrap();
+    ///
+    /// backoff.for_task_started_at(started_at)
+    ///     .should_retry(0); // RetryDecision::DoNotRetry
     /// ```
-    pub fn build_with_total_retry_duration(self, total_duration: Duration) -> ExponentialBackoff {
-        let mut out = self.build_with_max_retries(0);
-
-        const MEAN_JITTER: f64 = (MIN_JITTER + MAX_JITTER) / 2.0;
-
-        let delays = (0u32..).into_iter().map(|n| {
-            let min_interval = out.min_retry_interval;
-            let backoff_factor = out.backoff_exponent.checked_pow(n).unwrap_or(u32::MAX);
-            let n_delay = (min_interval * backoff_factor).mul_f64(MEAN_JITTER);
-            cmp::min(n_delay, out.max_retry_interval)
-        });
-
-        let mut approx_total = Duration::from_secs(0);
-        for (n, delay) in delays.enumerate() {
-            approx_total += delay;
-            if approx_total >= total_duration {
-                out.max_n_retries = (n + 1) as _;
-                break;
-            } else if delay == out.max_retry_interval {
-                // Optimisation: The delay aint changing now
-                let remaining_s = (total_duration - approx_total).as_secs_f64();
-                let additional_tries = (remaining_s / delay.as_secs_f64()).ceil() as usize;
-                out.max_n_retries = (n + 1 + additional_tries) as _;
-                break;
-            }
+    pub fn build_with_total_retry_duration(
+        self,
+        total_duration: Duration,
+    ) -> ExponentialBackoffTimed {
+        ExponentialBackoffTimed {
+            inner: ExponentialBackoff {
+                min_retry_interval: self.min_retry_interval,
+                max_retry_interval: self.max_retry_interval,
+                max_n_retries: None,
+                max_total_retry_duration: Some(total_duration),
+                jitter: self.jitter,
+            },
         }
-
-        out
     }
 }
 
@@ -191,10 +242,11 @@ mod tests {
 
     fn get_retry_policy() -> ExponentialBackoff {
         ExponentialBackoff {
-            max_n_retries: 6,
+            max_n_retries: Some(6),
+            max_total_retry_duration: None,
             min_retry_interval: Duration::from_secs(1),
             max_retry_interval: Duration::from_secs(5 * 60),
-            backoff_exponent: 3,
+            jitter: Jitter::Full,
         }
     }
 
@@ -202,8 +254,8 @@ mod tests {
     fn if_n_past_retries_is_below_maximum_it_decides_to_retry() {
         // Arrange
         let policy = get_retry_policy();
-        let n_past_retries = (0..policy.max_n_retries).fake();
-        assert!(n_past_retries < policy.max_n_retries);
+        let n_past_retries = (0..policy.max_n_retries.unwrap()).fake();
+        assert!(n_past_retries < policy.max_n_retries.unwrap());
 
         // Act
         let decision = policy.should_retry(n_past_retries);
@@ -216,8 +268,8 @@ mod tests {
     fn if_n_past_retries_is_above_maximum_it_decides_to_mark_as_failed() {
         // Arrange
         let policy = get_retry_policy();
-        let n_past_retries = (policy.max_n_retries..).fake();
-        assert!(n_past_retries >= policy.max_n_retries);
+        let n_past_retries = (policy.max_n_retries.unwrap()..).fake();
+        assert!(n_past_retries >= policy.max_n_retries.unwrap());
 
         // Act
         let decision = policy.should_retry(n_past_retries);
@@ -233,7 +285,7 @@ mod tests {
         let max_interval = chrono::Duration::from_std(policy.max_retry_interval).unwrap();
 
         // Act
-        let decision = policy.should_retry(policy.max_n_retries - 1);
+        let decision = policy.should_retry(policy.max_n_retries.unwrap() - 1);
 
         // Assert
         match decision {
@@ -247,8 +299,7 @@ mod tests {
     #[test]
     fn overflow_backoff_exponent_does_not_cause_a_panic() {
         let policy = ExponentialBackoff {
-            max_n_retries: u32::MAX,
-            backoff_exponent: 2,
+            max_n_retries: Some(u32::MAX),
             ..get_retry_policy()
         };
         let max_interval = chrono::Duration::from_std(policy.max_retry_interval).unwrap();
@@ -271,5 +322,36 @@ mod tests {
     fn builder_invalid_retry_bounds() {
         // bounds are the wrong way round or invalid
         ExponentialBackoff::builder().retry_bounds(Duration::from_secs(3), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn does_not_retry_after_total_retry_duration() {
+        let backoff = ExponentialBackoff::builder()
+            .build_with_total_retry_duration(Duration::from_secs(24 * 60 * 60));
+
+        {
+            let started_at = Instant::now()
+                .checked_sub(Duration::from_secs(23 * 60 * 60))
+                .unwrap();
+
+            let decision = backoff.for_task_started_at(started_at).should_retry(0);
+
+            match decision {
+                RetryDecision::Retry { .. } => {}
+                _ => panic!("should retry"),
+            }
+        }
+        {
+            let started_at = Instant::now()
+                .checked_sub(Duration::from_secs(25 * 60 * 60))
+                .unwrap();
+
+            let decision = backoff.for_task_started_at(started_at).should_retry(0);
+
+            match decision {
+                RetryDecision::DoNotRetry => {}
+                _ => panic!("should not retry"),
+            }
+        }
     }
 }

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -24,7 +24,7 @@ pub struct ExponentialBackoff {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExponentialBackoffTimed {
     /// Maximum duration the retries can continue for, after which retries will stop.
-    max_total_retry_duration: Option<Duration>,
+    max_total_retry_duration: Duration,
 
     backoff: ExponentialBackoff,
 }
@@ -137,9 +137,7 @@ impl ExponentialBackoffTimed {
 
 impl ExponentialBackoffWithStart {
     fn trying_for_too_long(&self) -> bool {
-        self.inner
-            .max_total_retry_duration
-            .is_some_and(|max_d| max_d <= Self::elapsed(self.started_at))
+        self.inner.max_total_retry_duration <= Self::elapsed(self.started_at)
     }
 
     fn elapsed(started_at: DateTime<Utc>) -> Duration {
@@ -237,7 +235,7 @@ impl ExponentialBackoffBuilder {
         total_duration: Duration,
     ) -> ExponentialBackoffTimed {
         ExponentialBackoffTimed {
-            max_total_retry_duration: Some(total_duration),
+            max_total_retry_duration: total_duration,
             backoff: ExponentialBackoff {
                 min_retry_interval: self.min_retry_interval,
                 max_retry_interval: self.max_retry_interval,

--- a/src/policies/mod.rs
+++ b/src/policies/mod.rs
@@ -1,3 +1,5 @@
 mod exponential_backoff;
 
-pub use exponential_backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
+pub use exponential_backoff::{
+    ExponentialBackoff, ExponentialBackoffBuilder, ExponentialBackoffTimed,
+};

--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 
+/// A policy for deciding whether and when to retry.
 pub trait RetryPolicy {
     /// Determine if a task should be retried according to a retry policy.
     fn should_retry(&self, n_past_retries: u32) -> RetryDecision;
@@ -12,4 +13,16 @@ pub enum RetryDecision {
     Retry { execute_after: DateTime<Utc> },
     /// Give up.
     DoNotRetry,
+}
+
+/// How to apply jitter to the retry intervals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Jitter {
+    /// Don't apply any jitter.
+    None,
+    /// Jitter between 0 and the calculated backoff duration.
+    Full,
+    /// Jitter between `min_retry_interval` and the calculated backoff duration.
+    Bounded,
 }


### PR DESCRIPTION
# Summary

This PR fixes two main problems:

1. Jitter failing to be applied when reaching maximum retry intervals.
2. Inability to reliably set a maximum total retry duration.

This change replaces the decorrelated jitter variation with three options:

1. None
2. Full
3. Bounded

It also changes how 'maximum retry duration' is implemented. Before, there was no information about how long the task had been retrying, so there was no way to implement a correct 'maximum retry duration'.

This has been reimplemented to require the task's start time when setting a maximum retry duration.

# Details

## Jitter algorithms

Decorrelated jitter has a major flaw: clamping. Retry intervals can get repeatedly clamped to the maximum allowed duration. This effectively removes any jitter.

The implementation in this library is a variation which exacerbates this flaw.

For comparison, a standard exponential backoff algorithm:

```python
sleep = min(max_duration, min_duration * 2 ** attempt)
```

With “full jitter”:

```python
sleep = random_between(0, min(max_duration, min_duration * 2 ** attempt))
```

Whereas “decorrelated jitter” is this:

```python
sleep = min(max_duration, random_between(min_duration, prev_sleep * 3))
```

Let’s break this down into two parts:

```python
# First: increase the sleep value by multiplying it - can only be 3x max_duration
temp = random_between(min_duration, prev_sleep * 3)

# Second: clamp it
sleep = min(max_duration, temp)
```

The `sleep` duration will generally increase every iteration. With this algorithm, when the previous `sleep` grows as large as `max_duration` there is only a 1/3 chance of applying jitter. E.g.:

```python
max_duration = 10
min_duration = 1

prev_sleep = 10
sleep = min(10, random_between(1, 10 * 3))
```

This isn't *great*. In this case, 2/3 of the time the sleep will be the `max_duration`.

So, decorrelated jitter is this:

```python
sleep = min(max_duration, random_between(min_duration, prev_sleep * 3))
```

But instead, what our algorithm does is more like this:

```python
sleep = min(max_duration, (min_duration * base ** attempt) * random_between(0, 3))
```

Again, broken down:

```python
# Calculate a sleep value, can get unboundedly big!
temp = (min_duration * base ** attempt) * random_between(0, 3)

# Then clamp it
sleep = min(max_duration, temp)
```

Here, there is no real bound on how high `min_duration * exp ** attempt` can go. E.g.:

```python
min_duration = 1
max_duration = 900
base = 4

attempt = 10
sleep = min(900, (1 * 4 ** 10) * random_between(0, 3))
sleep = min(900, 1_048_576 * random_between(0, 3))
```

In this case we have a very small chance of any meaningful jitter: 0.0003% chance by my calculation.

## Total retry duration

The current implementation makes a guess at how many attempts it will take to exceed a given total duration. It can't be accurate because of the random jitter, so this is a best guess based on mean jitter.

### Propagating state

Again, decorrelated jitter is:

```python
sleep = min(max_duration, random_between(min_duration, prev_sleep * 3))
```

This relies on the previous `sleep` value. But the `should_retry(&self, n_past_retries: u32)` function doesn't have access to the previous sleep value, which is (presumably) why a variation on the algorithm was used.

Most similar retry libraries take `&mut self` rather than `&self` to keep track of this state internally.

For this library it might not help much though, because retry state is tracked _outside_ of the policy object. E.g. for retrying AMQP messages, we send the number of attempts in a header. The service receiving the retried message looks at the header to retrieve the state and makes the next retry decision based on that.

Before this change, "number of attempts" was the only state this library supported.

### Start times

In order to accurately stop retrying after a given total duration, we need to know how long we've been retrying for. The simplest way to do this is to propagate the task start duration.

The API has been changed to accommodate this, in a way which keeps the `RetryPolicy` trait as-is.

```rust
// Returns an `ExponentialBackoffTimed`
let backoff = ExponentialBackoff::builder()
    .build_with_total_retry_duration(Duration::from_secs(24 * 60 * 60));

let started_at = Utc::now()
    .checked_sub_signed(chrono::Duration::seconds(25 * 60 * 60))
    .unwrap();

backoff
    .for_task_started_at(started_at) // Need to supply a task start time to be able to call `should_retry()`
    .should_retry(0); // RetryDecision::DoNotRetry
```

## To do

- [x] Better changelog notes

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/rust-retry-policies/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/rust-retry-policies/blob/main/CHANGELOG.md
-->
