### PR TITLE
feat: Allow total duration with max retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Total duration algorithm can now be configured to also consider max retries, calculated applying max jitter
+- Total duration algorithm can now be configured to also consider max retries, calculated applying no jitter (1.0)
   - We enforce whatever comes first, total duration or max retries
 
 ## [0.2.0] - 2023-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2023-10-03
+## [0.2.1] - 2023-10-03
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.1] - 2023-10-03
+## [0.2.1] - 2023-10-09
 
 ### Added
 
 - Total duration algorithm can now be configured to also consider max retries, calculated applying no jitter (1.0)
   - We enforce whatever comes first, total duration or max retries
+- Exponential base is now configurable
 
 ## [0.2.0] - 2023-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2023-10-03
+
+### Added
+
+- Total duration algorithm can now be configured to also consider max retries, calculated applying max jitter
+  - We enforce whatever comes first, total duration or max retries
+
 ## [0.2.0] - 2023-07-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.1] - 2023-10-03
+## [0.3.0] - 2023-10-03
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retry-policies"
-version = "0.3.0"
+version = "0.2.1"
 authors = ["Luca Palmieri <lpalmieri@truelayer.com>"]
 edition = "2018"
 description = "A collection of plug-and-play retry policies for Rust projects."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retry-policies"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Luca Palmieri <lpalmieri@truelayer.com>"]
 edition = "2018"
 description = "A collection of plug-and-play retry policies for Rust projects."

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add `retry-policies` to your dependencies
 ```toml
 [dependencies]
 # ...
-retry-policies = "0.2.0"
+retry-policies = "0.3.0"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add `retry-policies` to your dependencies
 ```toml
 [dependencies]
 # ...
-retry-policies = "0.3.0"
+retry-policies = "0.2.1"
 ```
 
 ## License

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -24,9 +24,9 @@ pub struct ExponentialBackoff {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExponentialBackoffTimed {
     /// Maximum duration the retries can continue for, after which retries will stop.
-    pub max_total_retry_duration: Duration,
+    max_total_retry_duration: Duration,
 
-    pub backoff: ExponentialBackoff,
+    backoff: ExponentialBackoff,
 }
 
 /// Exponential backoff with a maximum retry duration, for a task with a known start time.
@@ -132,6 +132,11 @@ impl ExponentialBackoffTimed {
             inner: *self,
             started_at,
         }
+    }
+
+    /// Maximum number of allowed retries attempts.
+    pub fn max_retries(&self) -> Option<u32> {
+        self.backoff.max_n_retries
     }
 }
 
@@ -263,7 +268,7 @@ impl ExponentialBackoffBuilder {
     ///     .retry_bounds(Duration::from_secs(1), Duration::from_secs(6 * 60 * 60))
     ///     .build_with_total_retry_duration_and_max_retries(Duration::from_secs(24 * 60 * 60));
     ///
-    /// assert_eq!(exponential_backoff_timed.backoff.max_n_retries, Some(17));
+    /// assert_eq!(exponential_backoff_timed.max_retries(), Some(17));
     ///
     /// let started_at = Utc::now()
     ///     .checked_sub_signed(chrono::Duration::seconds(25 * 60 * 60))

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -285,12 +285,12 @@ impl ExponentialBackoffBuilder {
     ) -> ExponentialBackoffTimed {
         let mut max_n_retries = None;
 
-        const MAX_JITTER: f64 = 1.0;
+        const NO_JITTER: f64 = 1.0;
 
         let delays = (0u32..).map(|n| {
             let min_interval = self.min_retry_interval;
             let backoff_factor = 2_u32.checked_pow(n).unwrap_or(u32::MAX);
-            let n_delay = (min_interval * backoff_factor).mul_f64(MAX_JITTER);
+            let n_delay = (min_interval * backoff_factor).mul_f64(NO_JITTER);
             cmp::min(n_delay, self.max_retry_interval)
         });
 

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -251,8 +251,19 @@ impl ExponentialBackoffBuilder {
     }
 
     /// Builds an [`ExponentialBackoff`] with the given maximum total duration and calculates max
-    /// retries that should happen applying a 1.0 jitter factor.
-    /// We will enforce whatever comes first, max retries or total duration.
+    /// retries that should happen applying no jitter.
+    ///
+    /// For example if we set total duration 24 hours, with retry bounds [1s, 24h], we would calculate
+    /// 17 max retries, as 1s * pow(2, 16) = 65536s = ~18 hours and 18th attempt would be way
+    /// after the 24 hours total duration.
+    ///
+    /// If the 17th retry ends up being scheduled after 10 hours due to jitter, [`should_retry`]
+    /// will return false anyway: no retry will be allowed after total duration.
+    ///
+    /// If one of the 17 allowed retries for some reason (e.g. previous attempts taking a long time) ends up
+    /// being scheduled after total duration, [`should_retry`] will return false.
+    ///
+    /// Basically we will enforce whatever comes first, max retries or total duration.
     ///
     /// Requires the use of [`ExponentialBackoffTimed::for_task_started_at()`].
     ///

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -232,8 +232,8 @@ impl ExponentialBackoffBuilder {
     ///     .checked_sub_signed(chrono::Duration::seconds(25 * 60 * 60))
     ///     .unwrap();
     ///
-    /// backoff.for_task_started_at(started_at)
-    ///     .should_retry(0); // RetryDecision::DoNotRetry
+    /// let should_retry = backoff.for_task_started_at(started_at).should_retry(0);
+    /// assert!(matches!(RetryDecision::DoNotRetry, should_retry));
     /// ```
     pub fn build_with_total_retry_duration(
         self,
@@ -285,15 +285,16 @@ impl ExponentialBackoffBuilder {
     ///     .checked_sub_signed(chrono::Duration::seconds(25 * 60 * 60))
     ///     .unwrap();
     ///
-    /// exponential_backoff_timed.for_task_started_at(started_at)
-    ///     .should_retry(0); // RetryDecision::DoNotRetry
+    /// let should_retry = exponential_backoff_timed.for_task_started_at(started_at).should_retry(0);
+    /// assert!(matches!(RetryDecision::DoNotRetry, should_retry));
     ///
     /// let started_at = Utc::now()
     ///     .checked_sub_signed(chrono::Duration::seconds(1 * 60 * 60))
     ///     .unwrap();
     ///
-    /// exponential_backoff_timed.for_task_started_at(started_at)
-    ///     .should_retry(18); // RetryDecision::DoNotRetry
+    /// let should_retry = exponential_backoff_timed.for_task_started_at(started_at).should_retry(18);
+    /// assert!(matches!(RetryDecision::DoNotRetry, should_retry));
+    ///
     /// ```
     pub fn build_with_total_retry_duration_and_max_retries(
         self,


### PR DESCRIPTION
This PR fixes one main problem, which is the fact that using a total duration we are not able to set a limit to the number of retries that will be made inside that timeframe.

We added a new `build_with_total_retry_duration_and_max_retries` method to `ExponentialBackoffBuilder` that calculates the number of retries that should be made if jitter `1.0` was applied (which means no jitter).
Since jitter can be `0..1`, the calculated number of retries is effectively the max number of retries that can be made during that duration.

In `should_retry` we now check if either total duration or max attempts are exceeded.

We also made the exponential's base configurable: this will allow users to exponentially delay the retries more from one another.
The default remains `2`, so this isn't a breaking change.