### PR TITLE
implement RetryPolicy for ExponentialBackoffTimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Breaking] Implement `RetryPolicy` for `ExponentialBackoffTimed`, which requires a modification to the `should_retry` method of 
+    `RetryPolicy` in order to pass the time at which the task (original request) was started.
 
 ## [0.2.1] - 2023-10-09
 

--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -3,7 +3,8 @@ use chrono::{DateTime, Utc};
 /// A policy for deciding whether and when to retry.
 pub trait RetryPolicy {
     /// Determine if a task should be retried according to a retry policy.
-    fn should_retry(&self, n_past_retries: u32) -> RetryDecision;
+    fn should_retry(&self, request_start_time: DateTime<Utc>, n_past_retries: u32)
+        -> RetryDecision;
 }
 
 /// Outcome of evaluating a retry policy for a failed task.


### PR DESCRIPTION
This PR seeks to implement the changes discussed in https://github.com/TrueLayer/reqwest-middleware/issues/109.  Mainly: that there is not currently a way to define a `RetryPolicy` which can observe a maximum retry duration.  There did exist `ExponentialBackoffTimed` which, from what I can tell, sought to implement this, but since it did not implement `RetryPolicy` there was no way to pass it and have each new request have an independent start time.  I believe this also obsolesces the need for `ExponentialBackoffWithStart`, so I removed it.

I did consider another approach:
1. Rather than changing the `should_retry` API, we could keep the task start time in the `RetryPolicy` itself, but:
    * The soonest we'd be able to set the task start time would be in the first call to `should_retry`, which isn't really accurate
    * This makes the `RetryPolicy` implementation stateful, which I don't think makes sense considering only a single one is passed in. 
    * We could change the policy passed in to be more of a policy "factory" or add additional methods to `RetryPolicy` (like `request_started`, but those are even bigger changes.

Definitely open to other suggestions, though I think the code here is consistent with what was discussed in the linked ticket.  ~Will link the corresponding `reqwest_middleware` PR as well.~ [corresponding reqwest-middleware PR.](https://github.com/TrueLayer/reqwest-middleware/pull/113)