### PR TITLE
Drastically decrease dependency count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Breaking] Replace `chrono` with standard library types
+  - Replace `chrono::DateTime<Utc>` with `std::time::SystemTime`
+
+### Removed
+
+- Remove unused `anyhow` dependency
+- Remove `fake` dependency
+
 ## [0.3.0] - 2024-03-04
 - [Breaking] Implement `RetryPolicy` for `ExponentialBackoffTimed`, which requires a modification to the `should_retry` method of 
     `RetryPolicy` in order to pass the time at which the task (original request) was started.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,7 @@ keywords = ["retry", "policy", "backoff"]
 categories = ["network-programming"]
 
 [dependencies]
-chrono = { version = "0.4.19", features = ["clock"], default-features = false }
 rand = "0.8.4"
-anyhow = "1.0.42"
 
 [dev-dependencies]
 fake = "2.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ categories = ["network-programming"]
 
 [dependencies]
 rand = "0.8.4"
-
-[dev-dependencies]
-fake = "2.4.1"

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -324,7 +324,7 @@ impl ExponentialBackoffBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fake::Fake;
+    use rand::distributions::{Distribution, Uniform};
 
     fn get_retry_policy() -> ExponentialBackoff {
         ExponentialBackoff {
@@ -340,7 +340,8 @@ mod tests {
     fn if_n_past_retries_is_below_maximum_it_decides_to_retry() {
         // Arrange
         let policy = get_retry_policy();
-        let n_past_retries = (0..policy.max_n_retries.unwrap()).fake();
+        let n_past_retries =
+            Uniform::from(0..policy.max_n_retries.unwrap()).sample(&mut rand::thread_rng());
         assert!(n_past_retries < policy.max_n_retries.unwrap());
 
         // Act
@@ -354,7 +355,8 @@ mod tests {
     fn if_n_past_retries_is_above_maximum_it_decides_to_mark_as_failed() {
         // Arrange
         let policy = get_retry_policy();
-        let n_past_retries = (policy.max_n_retries.unwrap()..).fake();
+        let n_past_retries =
+            Uniform::from(policy.max_n_retries.unwrap()..=u32::MAX).sample(&mut rand::thread_rng());
         assert!(n_past_retries >= policy.max_n_retries.unwrap());
 
         // Act

--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -1,17 +1,16 @@
-use chrono::{DateTime, Utc};
+use std::time::SystemTime;
 
 /// A policy for deciding whether and when to retry.
 pub trait RetryPolicy {
     /// Determine if a task should be retried according to a retry policy.
-    fn should_retry(&self, request_start_time: DateTime<Utc>, n_past_retries: u32)
-        -> RetryDecision;
+    fn should_retry(&self, request_start_time: SystemTime, n_past_retries: u32) -> RetryDecision;
 }
 
 /// Outcome of evaluating a retry policy for a failed task.
 #[derive(Debug)]
 pub enum RetryDecision {
     /// Retry after the specified timestamp.
-    Retry { execute_after: DateTime<Utc> },
+    Retry { execute_after: SystemTime },
     /// Give up.
     DoNotRetry,
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Closes #17 

⚠️ This PR is a breaking change.

## Public API changes

- Removal of `chrono::DateTime<Utc>` from the public API in favor of `std::time::SystemTime`

---

This PR gets rid of the following dependencies:

- `anyhow`
- `chrono`
- `fake`

Before:

```
[aumetra@gazenot:~/Documents/Rust/retry-policies]$ wc -l Cargo.lock 
359 Cargo.lock
```

After:

```
[aumetra@gazenot:~/Documents/Rust/retry-policies]$ wc -l Cargo.lock 
75 Cargo.lock
```

The only remaining dependency is `rand` which makes sense because of the jitter calculation.  
All the other dependencies were rather easily replaced with either stdlib functions or with `rand` usage.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/rust-retry-policies/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/rust-retry-policies/blob/main/CHANGELOG.md
-->
