### PR TITLE
Improve bounded jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0](https://github.com/TrueLayer/retry-policies/compare/v0.4.0...v0.5.0) - 2025-04-25
+## [0.5.1](https://github.com/TrueLayer/retry-policies/compare/v0.5.0...v0.5.1) - 2025-05-14
+
+### Changed
+
+- Improved bounded jitter to use 50% of `min_retry_interval` instead of 100%.
+
+## [0.5.0](https://github.com/TrueLayer/retry-policies/compare/v0.4.0...v0.5.0) - 2025-05-14
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["retry", "policy", "backoff"]
 categories = ["network-programming"]
 
 [dependencies]
-rand = "0.8.4"
+rand = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retry-policies"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Luca Palmieri <lpalmieri@truelayer.com>"]
 edition = "2018"
 description = "A collection of plug-and-play retry policies for Rust projects."

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -329,8 +329,11 @@ impl ExponentialBackoffBuilder {
 }
 #[cfg(test)]
 mod tests {
+    use std::convert::TryFrom as _;
+
+    use rand::distr::{Distribution, Uniform};
+
     use super::*;
-    use rand::distributions::{Distribution, Uniform};
 
     fn get_retry_policy() -> ExponentialBackoff {
         ExponentialBackoff {
@@ -346,8 +349,9 @@ mod tests {
     fn if_n_past_retries_is_below_maximum_it_decides_to_retry() {
         // Arrange
         let policy = get_retry_policy();
-        let n_past_retries =
-            Uniform::from(0..policy.max_n_retries.unwrap()).sample(&mut rand::thread_rng());
+        let n_past_retries = Uniform::try_from(0..policy.max_n_retries.unwrap())
+            .unwrap()
+            .sample(&mut rand::rng());
         assert!(n_past_retries < policy.max_n_retries.unwrap());
 
         // Act
@@ -361,8 +365,9 @@ mod tests {
     fn if_n_past_retries_is_above_maximum_it_decides_to_mark_as_failed() {
         // Arrange
         let policy = get_retry_policy();
-        let n_past_retries =
-            Uniform::from(policy.max_n_retries.unwrap()..=u32::MAX).sample(&mut rand::thread_rng());
+        let n_past_retries = Uniform::try_from(policy.max_n_retries.unwrap()..=u32::MAX)
+            .unwrap()
+            .sample(&mut rand::rng());
         assert!(n_past_retries >= policy.max_n_retries.unwrap());
 
         // Act

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -256,7 +256,7 @@ impl ExponentialBackoffBuilder {
     ///
     /// let exponential_backoff_timed = ExponentialBackoff::builder()
     ///     .retry_bounds(Duration::from_secs(1), Duration::from_secs(6 * 60 * 60))
-    ///     .build_with_total_retry_duration_and_max_retries(Duration::from_secs(24 * 60 * 60));
+    ///     .build_with_total_retry_duration_and_limit_retries(Duration::from_secs(24 * 60 * 60));
     ///
     /// assert_eq!(exponential_backoff_timed.max_retries(), Some(17));
     ///

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -10,7 +10,7 @@ use std::{
 pub struct ExponentialBackoff {
     /// Maximum number of allowed retries attempts.
     pub max_n_retries: Option<u32>,
-    /// Minimum waiting time between two retry attempts (it can end up being lower when using full jitter).
+    /// Minimum waiting time between two retry attempts (it can end up being lower due to jitter).
     pub min_retry_interval: Duration,
     /// Maximum waiting time between two retry attempts.
     pub max_retry_interval: Duration,

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -87,9 +87,11 @@ impl RetryPolicy for ExponentialBackoff {
                 self.min_retry_interval * calculate_exponential(self.base, n_past_retries),
             );
 
-            let jittered_wait_for = self
-                .jitter
-                .apply(unjittered_wait_for, self.min_retry_interval);
+            let jittered_wait_for = self.jitter.apply(
+                unjittered_wait_for,
+                self.min_retry_interval,
+                &mut rand::rng(),
+            );
 
             let execute_after =
                 SystemTime::now() + clip(jittered_wait_for, self.max_retry_interval);

--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -1,4 +1,6 @@
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
+
+use rand::distributions::uniform::{UniformFloat, UniformSampler};
 
 /// A policy for deciding whether and when to retry.
 pub trait RetryPolicy {
@@ -25,4 +27,26 @@ pub enum Jitter {
     Full,
     /// Jitter between `min_retry_interval` and the calculated backoff duration.
     Bounded,
+}
+
+impl Jitter {
+    pub(crate) fn apply(&self, interval: Duration, min_interval: Duration) -> Duration {
+        match self {
+            Jitter::None => interval,
+            Jitter::Full => {
+                let jitter_factor =
+                    UniformFloat::<f64>::sample_single(0.0, 1.0, &mut rand::thread_rng());
+
+                interval.mul_f64(jitter_factor)
+            }
+            Jitter::Bounded => {
+                let jitter_factor =
+                    UniformFloat::<f64>::sample_single(0.0, 1.0, &mut rand::thread_rng());
+
+                let jittered_wait_for = (interval - min_interval).mul_f64(jitter_factor);
+
+                jittered_wait_for + min_interval
+            }
+        }
+    }
 }

--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -25,7 +25,7 @@ pub enum Jitter {
     None,
     /// Jitter between 0 and the calculated backoff duration.
     Full,
-    /// Jitter between `min_retry_interval` and the calculated backoff duration.
+    /// Jitter between 50% of `min_retry_interval` and the calculated backoff duration.
     Bounded,
 }
 

--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -40,10 +40,15 @@ impl Jitter {
                 interval.mul_f64(jitter_factor)
             }
             Jitter::Bounded => {
+                /// The lower bound for the calculated interval, as a fraction of the minimum
+                /// interval.
+                const MIN_BOUND_FRACTION: f64 = 0.5;
+
                 let jitter_factor =
                     UniformFloat::<f64>::sample_single(0.0, 1.0, &mut rand::thread_rng());
 
-                let jittered_wait_for = (interval - min_interval).mul_f64(jitter_factor);
+                let jittered_wait_for =
+                    (interval - min_interval.mul_f64(MIN_BOUND_FRACTION)).mul_f64(jitter_factor);
 
                 jittered_wait_for + min_interval
             }

--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, SystemTime};
 
-use rand::distributions::uniform::{UniformFloat, UniformSampler};
+use rand::distr::uniform::{UniformFloat, UniformSampler};
 
 /// A policy for deciding whether and when to retry.
 pub trait RetryPolicy {
@@ -34,8 +34,8 @@ impl Jitter {
         match self {
             Jitter::None => interval,
             Jitter::Full => {
-                let jitter_factor =
-                    UniformFloat::<f64>::sample_single(0.0, 1.0, &mut rand::thread_rng());
+                let jitter_factor = UniformFloat::<f64>::sample_single(0.0, 1.0, &mut rand::rng())
+                    .expect("Sample range should be valid");
 
                 interval.mul_f64(jitter_factor)
             }
@@ -44,8 +44,8 @@ impl Jitter {
                 /// interval.
                 const MIN_BOUND_FRACTION: f64 = 0.5;
 
-                let jitter_factor =
-                    UniformFloat::<f64>::sample_single(0.0, 1.0, &mut rand::thread_rng());
+                let jitter_factor = UniformFloat::<f64>::sample_single(0.0, 1.0, &mut rand::rng())
+                    .expect("Sample range should be valid");
 
                 let jittered_wait_for =
                     (interval - min_interval.mul_f64(MIN_BOUND_FRACTION)).mul_f64(jitter_factor);


### PR DESCRIPTION
## Problem

Bounded jitter would jitter between `min_retry_interval` and the current interval. If the first retry always uses `min_retry_interval` then it would never jitter the first retry.

## Solution

Use 50% of `min_retry_interval` as the lower bound.

Example:

- `min_retry_interval` = 1s
- First retry interval will always = 1s
- Current solution – will jitter between min interval (1s) and current interval (1s) resulting in no jitter
- New solution – will jitter between 50% of min interval (0.5s) and current interval (1s)