### PR TITLE
Fix example/doctest that called old API

### DIFF
--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -272,7 +272,7 @@ impl ExponentialBackoffBuilder {
     ///
     /// let exponential_backoff_timed = ExponentialBackoff::builder()
     ///     .retry_bounds(Duration::from_secs(1), Duration::from_secs(6 * 60 * 60))
-    ///     .build_with_total_retry_duration_and_max_retries(Duration::from_secs(24 * 60 * 60));
+    ///     .build_with_total_retry_duration_and_limit_retries(Duration::from_secs(24 * 60 * 60));
     ///
     /// assert_eq!(exponential_backoff_timed.max_retries(), Some(17));
     ///


### PR DESCRIPTION
Fix an example that called `build_with_total_retry_duration_and_max_retries` without the second argument `max_n_retries`, by calling the new `build_with_total_retry_duration_and_limit_retries` instead.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/rust-retry-policies/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/rust-retry-policies/blob/main/CHANGELOG.md
-->

This fixes `cargo test` failing with the 0.5.0 release:

```
failures:

---- src/policies/exponential_backoff.rs - policies::exponential_backoff::ExponentialBackoffBuilder::build_with_total_retry_duration_and_limit_retries (line 268) stdout ----
error[E0061]: this method takes 2 arguments but 1 argument was supplied
   --> src/policies/exponential_backoff.rs:276:6
    |
11  |     .build_with_total_retry_duration_and_max_retries(Duration::from_secs(24 * 60 * 60));
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------- argument #2 of type `u32` is missing
    |
note: method defined here
   --> /home/ben/src/forks/retry-policies/src/policies/exponential_backoff.rs:329:12
    |
329 |     pub fn build_with_total_retry_duration_and_max_retries(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: provide the argument
    |
11  -     .build_with_total_retry_duration_and_max_retries(Duration::from_secs(24 * 60 * 60));
11  +     .build_with_total_retry_duration_and_max_retries(Duration::from_secs(24 * 60 * 60), /* u32 */);
    |

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0061`.
Couldn't compile the test.

failures:
    src/policies/exponential_backoff.rs - policies::exponential_backoff::ExponentialBackoffBuilder::build_with_total_retry_duration_and_limit_retries (line 268)

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
```