### PR TITLE
Bump rand to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `rand` version to `0.9.1`
+
 ## [0.5.0](https://github.com/TrueLayer/retry-policies/compare/v0.4.0...v0.5.0) - 2025-04-25
 
 ### Changed
@@ -32,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2024-03-04
 
 - [Breaking] Implement `RetryPolicy` for `ExponentialBackoffTimed`, which requires a modification to the `should_retry` method of
-    `RetryPolicy` in order to pass the time at which the task (original request) was started.
+  `RetryPolicy` in order to pass the time at which the task (original request) was started.
 
 ## [0.2.1] - 2023-10-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["retry", "policy", "backoff"]
 categories = ["network-programming"]
 
 [dependencies]
-rand = "0.8.4"
+rand = "0.9.1"


### PR DESCRIPTION
Bump the version of `rand` to 0.9.1, the latest version  at time of writing.

Upgrade guide: https://rust-random.github.io/book/update-0.9.html

* A few packages and methods were renamed
* Sample methods return a Result instead of panicking. Since the ranges in use here are constant, calling unwrap to avoid changing the interface made sense.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/rust-retry-policies/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/rust-retry-policies/blob/main/CHANGELOG.md
-->
