### PR TITLE
Wasm compatibility

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved bounded jitter to use 50% of `min_retry_interval` instead of 100%.
 
+### Added
+
+- compatibility with `wasm32-unknown-unknown`
+
 ## [0.5.0](https://github.com/TrueLayer/retry-policies/compare/v0.4.0...v0.5.0) - 2025-05-14
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,9 @@ keywords = ["retry", "policy", "backoff"]
 categories = ["network-programming"]
 
 [dependencies]
-rand = { version = "0.9.1", default-features = false }
+rand = "0.9.1"
 web-time = "1.1.0"
+getrandom = { version = "0.3.3", features = ["wasm_js"], optional = true }
+
+[features]
+wasm = ["rand/small_rng", "getrandom"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ keywords = ["retry", "policy", "backoff"]
 categories = ["network-programming"]
 
 [dependencies]
-rand = "0.9.1"
+rand = { version = "0.9.1", default-features = false }
+web-time = "1.1.0"

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -1,8 +1,8 @@
 use crate::{Jitter, RetryDecision, RetryPolicy};
 use std::{
     cmp::{self, min},
-    time::{Duration, SystemTime},
 };
+use web_time::{Duration, SystemTime};
 
 /// Exponential backoff with optional jitter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -1,7 +1,5 @@
 use crate::{Jitter, RetryDecision, RetryPolicy};
-use std::{
-    cmp::{self, min},
-};
+use std::cmp::{self, min};
 use web_time::{Duration, SystemTime};
 
 /// Exponential backoff with optional jitter.

--- a/src/policies/exponential_backoff.rs
+++ b/src/policies/exponential_backoff.rs
@@ -36,7 +36,7 @@ pub struct ExponentialBackoffTimed {
 /// ```rust
 /// use retry_policies::{RetryDecision, RetryPolicy, Jitter};
 /// use retry_policies::policies::ExponentialBackoff;
-/// use std::time::Duration;
+/// use web_time::Duration;
 ///
 /// let backoff = ExponentialBackoff::builder()
 ///     .retry_bounds(Duration::from_secs(1), Duration::from_secs(60))
@@ -57,7 +57,7 @@ impl ExponentialBackoff {
     /// # Example
     /// ```
     /// use retry_policies::policies::ExponentialBackoff;
-    /// use std::time::Duration;
+    /// use web_time::Duration;
     ///
     /// let backoff = ExponentialBackoff::builder()
     ///     .build_with_max_retries(5);
@@ -202,7 +202,7 @@ impl ExponentialBackoffBuilder {
     /// ```rust
     /// use retry_policies::{RetryDecision, RetryPolicy};
     /// use retry_policies::policies::ExponentialBackoff;
-    /// use std::time::{Duration, SystemTime};
+    /// use web_time::{Duration, SystemTime};
     ///
     /// let backoff = ExponentialBackoff::builder()
     ///     .build_with_total_retry_duration(Duration::from_secs(24 * 60 * 60));
@@ -254,7 +254,7 @@ impl ExponentialBackoffBuilder {
     /// ```rust
     /// use retry_policies::{RetryDecision, RetryPolicy};
     /// use retry_policies::policies::ExponentialBackoff;
-    /// use std::time::{Duration, SystemTime};
+    /// use web_time::{Duration, SystemTime};
     ///
     /// let exponential_backoff_timed = ExponentialBackoff::builder()
     ///     .retry_bounds(Duration::from_secs(1), Duration::from_secs(6 * 60 * 60))

--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, SystemTime};
+use web_time::{Duration, SystemTime};
 
 use rand::{
     distr::uniform::{UniformFloat, UniformSampler},
@@ -70,7 +70,7 @@ mod tests {
     use rand::{rngs::StdRng, SeedableRng};
 
     use super::*;
-    use std::time::Duration;
+    use web_time::Duration;
 
     const SEED: u64 = 3097268606784207815;
 


### PR DESCRIPTION
This pull request introduces compatibility with the `wasm32-unknown-unknown` target and replaces the standard library's time utilities with the `web_time` crate to improve cross-platform support. The changes also include updates to dependencies and documentation to reflect these enhancements.

### Motivation
I am using `dioxus` and `reqwest` to send requests from the frontend to the backend. To enhance the client functionality, I needed to use [`reqwest-middleware`](https://crates.io/crates/reqwest-middleware) and [`reqwest-retry`](https://crates.io/crates/reqwest-retry). However, when trying this in a WASM environment, I encountered a runtime panic. Message below is from the browser’s developer tools:
```
panicked at library/std/src/sys/pal/wasm/../unsupported/time.rs:31:9:
time not implemented on this platform
```
This panic occurs because this crates use `std::time::{Duration, SystemTime}`, which are not supported in `wasm32-unknown-unknown`.

To resolve this, I replaced those with the `web_time` crate.

### Compatibility with `wasm32-unknown-unknown` target:
- [`.cargo/config.toml`](diffhunk://#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268R1-R2): Added `rustflags` configuration for the `wasm32-unknown-unknown` target to specify the `getrandom_backend="wasm_js"` feature. Please refer [getrandom doc](https://docs.rs/getrandom/latest/getrandom/#webassembly-support) to see why this config is necessary(for checking if this crate is buildable on `wasm32-unknown-unknown` by `cargo build --features=wasm --target=wasm32-unknown-unknown`)
- [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R14-R18): Added new dependencies (`web-time`, `getrandom`) and defined a `wasm` feature for compatibility with the `wasm32-unknown-unknown` target.

### Transition to `web_time` crate:
- [`src/policies/exponential_backoff.rs`](diffhunk://#diff-375bf27a13529254fcd25d253dbe06cb1115c1238ccea7f1778c40befdf82fb9L2-R3): Replaced `std::time::{Duration, SystemTime}` with `web_time::{Duration, SystemTime}` across the file, including examples and implementations. [[1]](diffhunk://#diff-375bf27a13529254fcd25d253dbe06cb1115c1238ccea7f1778c40befdf82fb9L2-R3) [[2]](diffhunk://#diff-375bf27a13529254fcd25d253dbe06cb1115c1238ccea7f1778c40befdf82fb9L39-R37) [[3]](diffhunk://#diff-375bf27a13529254fcd25d253dbe06cb1115c1238ccea7f1778c40befdf82fb9L60-R58) [[4]](diffhunk://#diff-375bf27a13529254fcd25d253dbe06cb1115c1238ccea7f1778c40befdf82fb9L205-R203) [[5]](diffhunk://#diff-375bf27a13529254fcd25d253dbe06cb1115c1238ccea7f1778c40befdf82fb9L257-R255)
- [`src/retry_policy.rs`](diffhunk://#diff-10dc029eee47bc3b75d9f72d0d9b201ba46dee8dc1907acab6fb0ba05e60b2e2L1-R1): Updated imports to use `web_time::{Duration, SystemTime}` instead of the standard library equivalents. [[1]](diffhunk://#diff-10dc029eee47bc3b75d9f72d0d9b201ba46dee8dc1907acab6fb0ba05e60b2e2L1-R1) [[2]](diffhunk://#diff-10dc029eee47bc3b75d9f72d0d9b201ba46dee8dc1907acab6fb0ba05e60b2e2L73-R73)

### Documentation updates:
- [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR16-R19): Added a note about compatibility with `wasm32-unknown-unknown` in the changelog under the "Added" section.