### PR TITLE
Bump rand from 0.9.1 to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["retry", "policy", "backoff"]
 categories = ["network-programming"]
 
 [dependencies]
-rand = "0.9.1"
+rand = "0.10.1"


### PR DESCRIPTION
This bumps `rand` from 0.9.1 to 0.10.1. No functional changes 🙂 

Closes #31.
